### PR TITLE
DOC: change "acceptance angle" to "incident angle" in all cases

### DIFF
--- a/src/multianalyzer/_multianalyzer.pyx
+++ b/src/multianalyzer/_multianalyzer.pyx
@@ -120,7 +120,7 @@ cdef class MultiAnalyzer:
         :param L2: distance from the analyzer to the detector 
         :param pixel: pixel size
         :param center: position of the center on the detector (in pixel)
-        :param tha: acceptance angle of the analyzer crystal(°)
+        :param tha: incident angle of the analyzer crystal(°) (Bragg angle)
         :param thd: diffraction angle of the analyzer crystal(°) 2x tha
         :param psi: Offset of angles (in 2th) of the analyzer crystals
         :param rollx: mis-orientation of the analyzer along x (°)

--- a/src/multianalyzer/file_io.py
+++ b/src/multianalyzer/file_io.py
@@ -95,7 +95,7 @@ def ID22_bliss_parser(infile, entries=None, exclude_entries=None, block_size=Non
     
     
     :return: dict with entries containing each:
-        * tha: the acceptance angle of the analyzer
+        * tha: incident angle of the analyzer crystal(°) (Bragg angle)
         * thd: the diffractio angle of the analyzer (~2*tha)
         * roicol: A collection of ROI for each frame OR
         * roicol_lst: a list of BlockDescriptor to be read by the RoiColReader

--- a/src/multianalyzer/opencl.py
+++ b/src/multianalyzer/opencl.py
@@ -28,7 +28,7 @@ class OclMultiAnalyzer:
         :param L2: distance from the analyzer to the detector 
         :param pixel: pixel size
         :param center: position of the center on the detector (in pixel)
-        :param tha: acceptance angle of the analyzer crystal(°)
+        :param tha: incident angle of the analyzer crystal(°) (Bragg angle)
         :param thd: diffraction angle of the analyzer crystal(°) 2x tha
         :param psi: Offset of angles (in 2th) of the analyzer crystals
         :param rollx: mis-orientation of the analyzer along x (°)


### PR DESCRIPTION
This reduces confusion with "acceptance angle" meaning the bandwidth of the crystals instead of the angle between the diffractometer arm (ϴ_a from https://doi.org/10.1107/S1600576721005288).